### PR TITLE
Fixing anchor in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var CastDeviceEmulator = require('chromecast-device-emulator');
 var emulator = new CastDeviceEmulator();
 ```
 
-Load and serve your [pre-recorded scenario JSON file](#what-is-a-scenario-json-file)
+Load and serve your [pre-recorded scenario JSON file](#what-is-a-pre-recorded-scenario-json-file)
 
 ```javascript
 // Load pre-recorded scenario

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To run as a CLI, we can install executable npm package globally:
 $ npm install chromecast-device-emulator -g
 ```
 
-Startup the emulator with a [pre-recorded scenario json file](#what-is-a-scenario-json-file)
+Startup the emulator with a [pre-recorded scenario JSON file](#what-is-a-pre-recorded-scenario-json-file)
 
 ```bash
 $ chromecast-device-emulator start scenario.json


### PR DESCRIPTION
The link to `#what-is-a-pre-recorded-scenario-json-file` is pointing to an undefined title, so this PR just updates the README :)